### PR TITLE
Modified Target Framework

### DIFF
--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 6.0.8
     - name: Restore Dependencies
       run: dotnet restore ./New/bot/bot.csproj
     - name: Build

--- a/New/bot/bot.csproj
+++ b/New/bot/bot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>


### PR DESCRIPTION
Target framework has been selected to run on .NET 6.0. The YAML file for the build GitHub workflow has also been modified to specifically build for 6.0.8, and also renamed.