### PR TITLE
Updates to `settings.json`

### DIFF
--- a/New/bot/Config/AppConfig.cs
+++ b/New/bot/Config/AppConfig.cs
@@ -14,7 +14,7 @@ namespace Bot.Config
                 .AddJsonFile($"Config/settings.json")
                 .Build();
 
-            settings = config.GetSection(ReleaseMode.Mode).Get<Settings>();
+            settings = config.GetSection("Settings").Get<Settings>();
         }
     }
 }

--- a/New/bot/Config/ReleaseMode.cs
+++ b/New/bot/Config/ReleaseMode.cs
@@ -11,9 +11,9 @@
             get
             {
                 #if DEBUG
-                    return "DevSettings";
+                    return "Dev";
                 #else
-                    return "ProdSettings";
+                    return "Prod";
                 #endif
             }
         }

--- a/New/bot/Handlers/MessageEventHandler.cs
+++ b/New/bot/Handlers/MessageEventHandler.cs
@@ -62,7 +62,7 @@ namespace Bot.Handlers
             //Logger.Info("Message received! Channel origin: " + message.Channel.Name);
 
             // Debugging purposes
-            if (ReleaseMode.Mode == "ProdSettings")
+            if (ReleaseMode.Mode == "Prod")
             {
                 // Cast to TextChannel before category ID can be obtained
                 var chan = message.Channel as SocketTextChannel;
@@ -122,7 +122,7 @@ namespace Bot.Handlers
             var msg = message.Value as SocketMessage;
 
             // Debugging purposes
-            if (ReleaseMode.Mode == "ProdSettings")
+            if (ReleaseMode.Mode == "Prod")
             {
                 var broadcastId = await ChannelHelper.GetChannelId(_mongoClient, "admin-tools",
                     "text", "bot-alerts");
@@ -206,7 +206,7 @@ namespace Bot.Handlers
 
             var approvedChannelsId = approvedChannels.Values.ToList();
 
-            if (!approvedChannelsId.Contains(chanId) && ReleaseMode.Mode == "ProdSettings")
+            if (!approvedChannelsId.Contains(chanId) && ReleaseMode.Mode == "Prod")
                 return;
 
             var content = message.Content.ToLower();

--- a/New/bot/Handlers/VoiceEventHandler.cs
+++ b/New/bot/Handlers/VoiceEventHandler.cs
@@ -41,7 +41,7 @@ namespace Bot.Handlers
             Logger.Info("VC state has changed!");
 
             // Debugging purposes
-            if (ReleaseMode.Mode == "ProdSettings")
+            if (ReleaseMode.Mode == "Prod")
             {
                 var catId = previousVc.Category.Id;
 
@@ -70,7 +70,7 @@ namespace Bot.Handlers
             var vcs = await DatabaseService.GetCategoryVoiceChannels(_mongoClient, "lfg-events");
 
             // Debugging purposes
-            if (ReleaseMode.Mode == "ProdSettings")
+            if (ReleaseMode.Mode == "Prod")
                 defaultName = ChannelHelper.GetChannelName(vcId, vcs);
             else
                 defaultName = "General";

--- a/New/bot/bot.csproj
+++ b/New/bot/bot.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="NLog" Version="5.1.1" />
   </ItemGroup>
 
-  <!--<ItemGroup>
+  <ItemGroup>
     <Content Include="Config\settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>-->
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Plugins\" />


### PR DESCRIPTION
The `settings.json` is a file used that carries different URIs, such as the token, the DB connection URL, etc. Previously, two objects were being maintained in the file: a dev and a prod. This was then shortened to only carry one object: the VPS service will have the prod copy, with the dev copy being kept locally.

A review will be done later before confirming the pull request.