### PR TITLE
Commented out copy-over line that causes issue with build workflow

### DIFF
--- a/New/bot/bot.csproj
+++ b/New/bot/bot.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="NLog" Version="5.1.1" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!--<ItemGroup>
     <Content Include="Config\settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
+  </ItemGroup>-->
 
   <ItemGroup>
     <Folder Include="Plugins\" />


### PR DESCRIPTION
As the title says. A copy command to the output folder caused the build workflow to fail due to there not being a `settings.json`.