### PR TITLE
Versioning - Modified build workflow

### DIFF
--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore ./New/bot/bot.csproj
     - name: Build
-      run: dotnet build ./New/bot/bot.csproj --configuration Release --no-restore
+      run: dotnet build ./New/bot/bot.csproj --configuration Release --version-suffix ${{ github.event.pull_request.head.sha }} --no-restore
     - name: Archive Build
       uses: actions/upload-artifact@v3
       with:

--- a/New/bot/bot.csproj
+++ b/New/bot/bot.csproj
@@ -10,8 +10,6 @@
 	<PropertyGroup>
 		<Description>"A bot powered by Discord.NET!"</Description>
 		<VersionPrefix>3.0.0</VersionPrefix>
-		<VersionSuffix Condition=" '$(BUILD_BUILDNUMBER)' == ''">local</VersionSuffix>
-		<VersionSuffix Condition=" '$(BUILD_BUILDNUMBER)' != ''">$(BUILD_BUILDNUMBER)</VersionSuffix>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
The build workflow should (hopefully) place the sha commit as the version prefix.