### PR TITLE
Remove/Assign `Explorer` role depending on circumstance

### DIFF
--- a/New/BotTests/DatabaseServiceTests.cs
+++ b/New/BotTests/DatabaseServiceTests.cs
@@ -41,5 +41,18 @@ namespace BotTests
             Assert.IsNotNull(responseRoles);
             Assert.IsNotNull(responseWatchlist);
         }
+
+        [TestMethod]
+        public void CheckIfIdRetrievalFails()
+        {
+            string catName = "Server Management Roles";
+
+            var taskActiveCommander = dbService.
+                GrabUserRoleIdByName(catName, "Active Commander");
+            taskActiveCommander.Wait();
+            var responseActiveCommander = taskActiveCommander.Result;
+
+            Assert.AreEqual((ulong)739588924896444417, responseActiveCommander);
+        }
     }
 }

--- a/New/BotTests/DatabaseServiceTests.cs
+++ b/New/BotTests/DatabaseServiceTests.cs
@@ -52,7 +52,37 @@ namespace BotTests
             taskActiveCommander.Wait();
             var responseActiveCommander = taskActiveCommander.Result;
 
+            var taskAOCommander = dbService.
+                GrabUserRoleIdByName(catName, "AO Commander");
+            taskAOCommander.Wait();
+            var responseAOCommander = taskAOCommander.Result;
+
+            var taskComTag = dbService.
+                GrabUserRoleIdByName(catName, "Commander Tag");
+            taskComTag.Wait();
+            var responseComTag = taskComTag.Result;
+
+            var taskTrader = dbService.
+                GrabUserRoleIdByName(catName, "Trader");
+            taskTrader.Wait();
+            var responseTrader = taskTrader.Result;
+
+            var taskInstanceTrainer = dbService.
+                GrabUserRoleIdByName(catName, "Instance Content Trainer");
+            taskInstanceTrainer.Wait();
+            var responseInstanceTrainer = taskInstanceTrainer.Result;
+
+            var taskExplorer = dbService.
+                GrabUserRoleIdByName(catName, "Explorer");
+            taskInstanceTrainer.Wait();
+            var responseExplorer = taskExplorer.Result;
+
             Assert.AreEqual((ulong)739588924896444417, responseActiveCommander);
+            Assert.AreEqual((ulong)853403399311065109, responseAOCommander);
+            Assert.AreEqual((ulong)716046608185163887, responseComTag);
+            Assert.AreEqual((ulong)761845222886866995, responseTrader);
+            Assert.AreEqual((ulong)1061761196597985370, responseInstanceTrainer);
+            Assert.AreEqual((ulong)747362590270947398, responseExplorer);
         }
     }
 }

--- a/New/bot/ExaltedSage/ExaltedSage.cs
+++ b/New/bot/ExaltedSage/ExaltedSage.cs
@@ -66,7 +66,8 @@ namespace Bot
             _logService = new LogService(_discordClient);
 
             // Guild member events
-
+            _discordClient.GuildMemberUpdated 
+                += _guildMemberEventHandler.GuildMemberUpdatedAsync;
 
             //_discordClient.SlashCommandExecuted += _slashCommandHandler.SlashCommandExecute;
             // Message events

--- a/New/bot/ExaltedSage/ExaltedSage.cs
+++ b/New/bot/ExaltedSage/ExaltedSage.cs
@@ -69,6 +69,7 @@ namespace Bot
 
             // User events
             _discordClient.UserLeft += _userHandler.UserLeftAsync;
+            _discordClient.UserUpdated += _userHandler.UserUpdatedAsync;
 
             // Voice channel events
             _discordClient.UserVoiceStateUpdated += _voiceHandler.VoiceStateChangeAsync;

--- a/New/bot/ExaltedSage/ExaltedSage.cs
+++ b/New/bot/ExaltedSage/ExaltedSage.cs
@@ -29,6 +29,7 @@ namespace Bot
 
         // Handlers
         //private readonly SlashCommandHandler _slashCommandHandler;
+        private readonly GuildMemberEventHandler _guildMemberEventHandler;
         private readonly MessageEventHandler _messageHandler;
         private readonly UserEventHandler _userHandler;
         private readonly VoiceEventHandler _voiceHandler;
@@ -53,6 +54,8 @@ namespace Bot
                 appSettings.settings.ConnectionUri);
 
             //_slashCommandHandler = new SlashCommandHandler();
+            _guildMemberEventHandler = new GuildMemberEventHandler
+                (_discordClient, _databaseService);
             _messageHandler = new MessageEventHandler(_discordClient,
                 _databaseService);
             _userHandler = new UserEventHandler(_discordClient,
@@ -62,6 +65,9 @@ namespace Bot
 
             _logService = new LogService(_discordClient);
 
+            // Guild member events
+
+
             //_discordClient.SlashCommandExecuted += _slashCommandHandler.SlashCommandExecute;
             // Message events
             _discordClient.MessageReceived += _messageHandler.MessageReceivedAsync;
@@ -69,7 +75,6 @@ namespace Bot
 
             // User events
             _discordClient.UserLeft += _userHandler.UserLeftAsync;
-            _discordClient.UserUpdated += _userHandler.UserUpdatedAsync;
 
             // Voice channel events
             _discordClient.UserVoiceStateUpdated += _voiceHandler.VoiceStateChangeAsync;

--- a/New/bot/Handlers/GuildMemberEventHandler.cs
+++ b/New/bot/Handlers/GuildMemberEventHandler.cs
@@ -1,0 +1,119 @@
+﻿using Discord;
+using Discord.WebSocket;
+using NLog;
+using MongoDB.Driver;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Bot.Config;
+using Bot.Helpers;
+using Bot.Services;
+using System;
+
+namespace Bot.Handlers
+{
+    /// <summary>
+    ///     Handles any guild member-related events
+    /// </summary>
+    public class GuildMemberEventHandler
+    {
+        private readonly DiscordSocketClient _discordClient;
+        private readonly DatabaseService _dbService;
+
+        public GuildMemberEventHandler(DiscordSocketClient discordClient,
+            DatabaseService dbService)
+        {
+            _discordClient = discordClient;
+            _dbService = dbService;
+        }
+
+        public async Task
+            GuildMemberUpdatedAsync(Cacheable<SocketGuildUser, UInt64> previous,
+            SocketGuildUser current)
+        {
+            var prev = previous.Value;
+            var explorerId = await _dbService
+                .GrabUserRoleIdByName("Server Management Roles",
+                "Explorer");
+
+            // Debugging purposes
+            if (ReleaseMode.Mode == "Prod")
+            {
+                if (CheckIfGainedGilded(prev, current))
+                {
+                    await current.RemoveRoleAsync(explorerId);
+                }
+                else
+                {
+                    await current.AddRoleAsync(explorerId);
+                }
+            }
+            else
+            {
+                if (CheckIfGainedGilded(prev, current))
+                {
+                    await current.RemoveRoleAsync(explorerId);
+                }
+                else
+                {
+                    await current.AddRoleAsync(explorerId);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Checks to see if the given user contains a
+        ///     specified role.
+        /// </summary>
+        /// <param name="user">
+        ///     The user to check for their roles.
+        /// </param>
+        /// <param name="roleName">
+        ///     The name of the role to look for.
+        /// </param>
+        /// <returns>
+        ///     True if the user has the role, false otherwise.
+        /// </returns>
+        private static bool CheckForRole(SocketGuildUser user, string roleName)
+        {
+            var userRoles = user.Roles.ToList();
+
+            if (userRoles.Any(role => role.Name == roleName))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Checks to see if the user has gained or lost the Gilded
+        ///     role. This is a role that's assigned/removed by a
+        ///     third-party bot.
+        /// </summary>
+        /// <param name="previous">
+        ///     The previous state of the user.
+        /// </param>
+        /// <param name="current">
+        ///     The current state of the user.
+        /// </param>
+        /// <returns>
+        ///     True if the user gained the Gilded role, false
+        ///     otherwise.
+        /// </returns>
+        private static bool CheckIfGainedGilded(SocketGuildUser previous,
+            SocketGuildUser current)
+        {
+            if (!CheckForRole(previous, "Gilded") &&
+                CheckForRole(current, "Gilded"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+
+}

--- a/New/bot/Handlers/GuildMemberEventHandler.cs
+++ b/New/bot/Handlers/GuildMemberEventHandler.cs
@@ -44,7 +44,7 @@ namespace Bot.Handlers
                 {
                     await current.RemoveRoleAsync(explorerId);
                 }
-                else
+                else if (!CheckForRole(current, "Explorer"))
                 {
                     await current.AddRoleAsync(explorerId);
                 }

--- a/New/bot/Handlers/UserEventHandler.cs
+++ b/New/bot/Handlers/UserEventHandler.cs
@@ -94,42 +94,6 @@ namespace Bot.Handlers
             }
         }
 
-        public async Task UserUpdatedAsync(SocketUser previous,
-            SocketUser current)
-        {
-            // Cast to GuildUser
-            var gPrevious = previous as SocketGuildUser;
-            var gCurrent = current as SocketGuildUser;
-
-            // Debugging purposes
-            if (ReleaseMode.Mode == "Prod")
-            {
-                // Check to see if user has lost the Gilded role
-                if (CheckIfGainedGilded(gPrevious, gCurrent))
-                {
-                    // Update user's role to the Explorer role
-                    var explorerId = await _dbService.
-                        GrabUserRoleIdByName("Server Management Roles",
-                        "Explorer");
-
-                    await gCurrent.AddRoleAsync(explorerId);
-                }
-            }
-            else
-            {
-                // Check to see if user has lost the Gilded role
-                if (CheckIfGainedGilded(gPrevious, gCurrent))
-                {
-                    // Update user's role to the Explorer role
-                    var explorerId = await _dbService.
-                        GrabUserRoleIdByName("Server Management Roles",
-                        "Explorer");
-
-                    await gCurrent.AddRoleAsync(explorerId);
-                }
-            }
-        }
-
         /// <summary>
         ///     Checks to see if the user has any in-game guild roles.
         /// </summary>
@@ -177,40 +141,6 @@ namespace Bot.Handlers
 
             await broadcast.SendMessageAsync($"Alert <@&{leadershipIds.Item1}>" +
                 $" <@&{leadershipIds.Item2}>", embed: embed.Build());
-        }
-
-        private static bool CheckForRole(SocketGuildUser gUser, string roleName)
-        {
-            var gUserRoles = gUser.Roles.ToList();
-
-            if (gUserRoles.Any(role => role.Name == roleName))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        ///     Checks to see if the user has gained the Gilded role or
-        ///     has lost it.
-        /// </summary>
-        /// <param name="prevGUser"></param>
-        /// <param name="currentGUser"></param>
-        /// <returns>
-        ///     True if the user gained the Gilded role, false if they lost
-        ///     it
-        /// </returns>
-        private static bool CheckIfGainedGilded(SocketGuildUser prevGUser,
-            SocketGuildUser currentGUser)
-        {
-            if (CheckForRole(prevGUser, "Gilded") &&
-                !CheckForRole(currentGUser, "Gilded"))
-            {
-                return true;
-            }
-
-            return false;
         }
     }
 }

--- a/New/bot/Handlers/UserEventHandler.cs
+++ b/New/bot/Handlers/UserEventHandler.cs
@@ -94,6 +94,44 @@ namespace Bot.Handlers
             }
         }
 
+        public async Task UserUpdatedAsync(SocketUser previous,
+            SocketUser current)
+        {
+            // Cast to GuildUser
+            var gPrevious = previous as SocketGuildUser;
+            var gCurrent = current as SocketGuildUser;
+
+            // Debugging purposes
+            if (ReleaseMode.Mode == "Prod")
+            {
+                // Check to see if user has lost the Gilded role
+                if (CheckForGildedRole(gPrevious) &&
+                    !CheckForGildedRole(gCurrent))
+                {
+                    // Update user's role to the Explorer role
+                    var explorerId = await _dbService.
+                        GrabUserRoleIdByName("Server Management Roles",
+                        "Explorer");
+
+                    await gCurrent.AddRoleAsync(explorerId);
+                }
+            }
+            else
+            {
+                // Check to see if user has lost the Gilded role
+                if (CheckForGildedRole(gPrevious) &&
+                    !CheckForGildedRole(gCurrent))
+                {
+                    // Update user's role to the Explorer role
+                    var explorerId = await _dbService.
+                        GrabUserRoleIdByName("Server Management Roles",
+                        "Explorer");
+
+                    await gCurrent.AddRoleAsync(explorerId);
+                }
+            }
+        }
+
         /// <summary>
         ///     Checks to see if the user has any in-game guild roles.
         /// </summary>
@@ -141,6 +179,18 @@ namespace Bot.Handlers
 
             await broadcast.SendMessageAsync($"Alert <@&{leadershipIds.Item1}>" +
                 $" <@&{leadershipIds.Item2}>", embed: embed.Build());
+        }
+
+        private static bool CheckForGildedRole(SocketGuildUser gUser)
+        {
+            var gUserRoles = gUser.Roles.ToList();
+
+            if (gUserRoles.Any(role => role.Name == "Gilded"))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/New/bot/Handlers/UserEventHandler.cs
+++ b/New/bot/Handlers/UserEventHandler.cs
@@ -105,8 +105,7 @@ namespace Bot.Handlers
             if (ReleaseMode.Mode == "Prod")
             {
                 // Check to see if user has lost the Gilded role
-                if (CheckForGildedRole(gPrevious) &&
-                    !CheckForGildedRole(gCurrent))
+                if (CheckIfGainedGilded(gPrevious, gCurrent))
                 {
                     // Update user's role to the Explorer role
                     var explorerId = await _dbService.
@@ -119,8 +118,7 @@ namespace Bot.Handlers
             else
             {
                 // Check to see if user has lost the Gilded role
-                if (CheckForGildedRole(gPrevious) &&
-                    !CheckForGildedRole(gCurrent))
+                if (CheckIfGainedGilded(gPrevious, gCurrent))
                 {
                     // Update user's role to the Explorer role
                     var explorerId = await _dbService.
@@ -181,11 +179,33 @@ namespace Bot.Handlers
                 $" <@&{leadershipIds.Item2}>", embed: embed.Build());
         }
 
-        private static bool CheckForGildedRole(SocketGuildUser gUser)
+        private static bool CheckForRole(SocketGuildUser gUser, string roleName)
         {
             var gUserRoles = gUser.Roles.ToList();
 
-            if (gUserRoles.Any(role => role.Name == "Gilded"))
+            if (gUserRoles.Any(role => role.Name == roleName))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Checks to see if the user has gained the Gilded role or
+        ///     has lost it.
+        /// </summary>
+        /// <param name="prevGUser"></param>
+        /// <param name="currentGUser"></param>
+        /// <returns>
+        ///     True if the user gained the Gilded role, false if they lost
+        ///     it
+        /// </returns>
+        private static bool CheckIfGainedGilded(SocketGuildUser prevGUser,
+            SocketGuildUser currentGUser)
+        {
+            if (CheckForRole(prevGUser, "Gilded") &&
+                !CheckForRole(currentGUser, "Gilded"))
             {
                 return true;
             }

--- a/New/bot/Services/DatabaseService.cs
+++ b/New/bot/Services/DatabaseService.cs
@@ -161,10 +161,20 @@ namespace Bot.Services
 
         public async Task<Tuple<ulong, ulong>> GetLeadershipIds()
         {
-            var categoryCollection = GrabCollection<RolesDoc>("roles");
-            var cat = await GrabDocument(categoryCollection, "Guild Role IDs");
+            var roleCollection = GrabCollection<RolesDoc>("roles");
+            var roles = await GrabDocument(roleCollection, "Guild Role IDs");
 
-            return Tuple.Create(cat.Roles["Exalted"], cat.Roles["Ascended"]);
+            return Tuple.Create(roles.Roles["Exalted"], roles.Roles["Ascended"]);
+        }
+
+
+        public async Task<ulong> GrabUserRoleIdByName(string catName, string roleName)
+        {
+            var roleCollection = GrabCollection<RolesDoc>("roles");
+            var roles = await GrabDocument<RolesDoc>(roleCollection, catName);
+
+            // This might throw an error
+            return roles.Roles[roleName];
         }
 
         /// <summary>

--- a/New/bot/bot.csproj
+++ b/New/bot/bot.csproj
@@ -9,7 +9,7 @@
 
 	<PropertyGroup>
 		<Description>"A bot powered by Discord.NET!"</Description>
-		<VersionPrefix>3.1.3</VersionPrefix>
+		<VersionPrefix>3.2.0</VersionPrefix>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Best way to explain the changes being merged via this PR:

As a user joins the server, a bot (not this one!) assigns the `Explorer` role. This enables the user to see certain specific channels. Once they go through an application process, a bot (again, not this one and different than the previously mentioned one) assigns the user the `Gilded` role. However, the `Explorer` role is not automatically removed.

Similarly, if the user ends up being removed from the in-game guild, a bot (at this point, you should know it's not this one) removes the `Gilded` role, but the `Explorer` role is never reassigned, so the user ends up being in a weird state of limbo.

The changes being worked on is a new feature, so this will increase the `minor` version. What the bot should do is to remove the `Explorer` role if the user receives the `Gilded` role, and have the former be reassigned upon the lose of the latter. Straight-forward, right?

Relevant issue to this can be tracked via #60, where it's mostly me realizing I did something dummy, but for the sake of documenting, I talked about it.