### PR TITLE
Fixed some issues that was causing an unintentional feedback loop

### DIFF
--- a/New/bot/ExaltedSage/ExaltedSage.cs
+++ b/New/bot/ExaltedSage/ExaltedSage.cs
@@ -78,7 +78,8 @@ namespace Bot
             _discordClient.UserLeft += _userHandler.UserLeftAsync;
 
             // Voice channel events
-            _discordClient.UserVoiceStateUpdated += _voiceHandler.VoiceStateChangeAsync;
+            _discordClient.UserVoiceStateUpdated 
+                += _voiceHandler.VoiceStateChangeAsync;
 
             _discordClient.Log += _logService.LogAsync;
 

--- a/New/bot/Handlers/GuildMemberEventHandler.cs
+++ b/New/bot/Handlers/GuildMemberEventHandler.cs
@@ -106,7 +106,7 @@ namespace Bot.Handlers
             SocketGuildUser current)
         {
             if ((!HasRole(previous, "Gilded") && HasRole(current, "Gilded"))
-                && (HasRole(current, "Explorer"))
+                && (HasRole(current, "Explorer")))
             {
                 return true;
             }
@@ -119,8 +119,8 @@ namespace Bot.Handlers
         private static bool CheckIfLostGilded(SocketGuildUser previous,
             SocketGuildUser current)
         {
-            if ((HasRole(previous, "Gilded") && !HasRole(current, "Gilded")
-                && (!HasRole(current, "Explorer"))
+            if ((HasRole(previous, "Gilded") && !HasRole(current, "Gilded"))
+                && (!HasRole(current, "Explorer")))
             {
                 return true;
             }

--- a/New/bot/Handlers/GuildMemberEventHandler.cs
+++ b/New/bot/Handlers/GuildMemberEventHandler.cs
@@ -44,7 +44,7 @@ namespace Bot.Handlers
                 {
                     await current.RemoveRoleAsync(explorerId);
                 }
-                else if (!CheckForRole(current, "Explorer"))
+                else if (CheckIfLostGilded(prev, current))
                 {
                     await current.AddRoleAsync(explorerId);
                 }
@@ -75,7 +75,7 @@ namespace Bot.Handlers
         /// <returns>
         ///     True if the user has the role, false otherwise.
         /// </returns>
-        private static bool CheckForRole(SocketGuildUser user, string roleName)
+        private static bool HasRole(SocketGuildUser user, string roleName)
         {
             var userRoles = user.Roles.ToList();
 
@@ -105,8 +105,22 @@ namespace Bot.Handlers
         private static bool CheckIfGainedGilded(SocketGuildUser previous,
             SocketGuildUser current)
         {
-            if (!CheckForRole(previous, "Gilded") &&
-                CheckForRole(current, "Gilded"))
+            if ((!HasRole(previous, "Gilded") && HasRole(current, "Gilded"))
+                && (HasRole(current, "Explorer"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        // This has to check whether Gilded has been lost and role doesn't currently
+        // have the Explorer
+        private static bool CheckIfLostGilded(SocketGuildUser previous,
+            SocketGuildUser current)
+        {
+            if ((HasRole(previous, "Gilded") && !HasRole(current, "Gilded")
+                && (!HasRole(current, "Explorer"))
             {
                 return true;
             }

--- a/New/bot/bot.csproj
+++ b/New/bot/bot.csproj
@@ -9,7 +9,7 @@
 
 	<PropertyGroup>
 		<Description>"A bot powered by Discord.NET!"</Description>
-		<VersionPrefix>3.2.0</VersionPrefix>
+		<VersionPrefix>3.2.1</VersionPrefix>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Notable differences in the changes include a bit more of verbosity to make intent be clearer and to avoid missing a boundary condition that created a (short?) feedback loop.

Essentially: the `Explorer` role wasn't removed. These changes should fix it.