### PR TITLE
Connect/Disconnect Event Handlers

### DIFF
--- a/New/Bot/ExaltedSage/ExaltedSage.cs
+++ b/New/Bot/ExaltedSage/ExaltedSage.cs
@@ -123,7 +123,7 @@ namespace Bot
 
         private void StartServerResetEventTimer()
         {
-            if (_isServerResetTimerRunning)
+            if (!_isServerResetTimerRunning)
             {
                 _isServerResetTimerRunning = true;
 
@@ -224,25 +224,6 @@ namespace Bot
                 }
             }
         }
-
-        private void StartServerResetTimer()
-        {
-            //if ()
-        }
-
-        /// <summary>
-        ///     Calculates an hour delay from time of execution.
-        /// </summary>
-        /// <returns>
-        ///     An hour delay.
-        /// </returns>
-        //private static TimeSpan CalculateHourDelay()
-        //{
-        //    DateTime nextHour = DateTime.Now.AddHours(1);
-        //    TimeSpan delay = nextHour - DateTime.Now;
-
-        //    return delay;
-        //}
 
         /// <summary>
         ///     Wrapper class that periodically calls the async task.

--- a/New/Bot/ExaltedSage/ExaltedSage.cs
+++ b/New/Bot/ExaltedSage/ExaltedSage.cs
@@ -236,15 +236,15 @@ namespace Bot
         /// </param>
         /// <param name="cancellationToken"></param>
         /// 
-        //private static async Task PeriodicAsync(Func<Task> action,
-        //    TimeSpan interval, CancellationToken cancellationToken = default)
-        //{
-        //    using var timer = new PeriodicTimer(interval);
-        //    while (await timer.WaitForNextTickAsync(cancellationToken))
-        //    {
-        //        await action();
-        //    }
-        //}
+        private static async Task PeriodicAsync(Func<Task> action,
+            TimeSpan interval, CancellationToken cancellationToken = default)
+        {
+            using var timer = new PeriodicTimer(interval);
+            while (await timer.WaitForNextTickAsync(cancellationToken))
+            {
+                await action();
+            }
+        }
 
         private static DiscordSocketConfig GenerateConfig()
         {


### PR DESCRIPTION
So the scope of this branch seems to have gone out of the scope of making use of flags to prevent the bot from posting multiple times.

The fundamental issue actually stemmed from the bot handling multiple `Connected` requests that ended up firing the `OnServerReset()` function multiple times. Currently, this function does _not_ have a flag system in place to ensure it only gets executed _once_ every hour, and it may be implemented if the double-posting behavior continues.

However, what I'd like to refer to as `Task` guardrails are being used. This is more-or-less a method of ensuring that the `Ready` event completes (this is important as it signals to the client that guild data is available) before the `Connected` event (the handler starts a timer that runs periodic execution of the `OnServerReset()` method).